### PR TITLE
Minor improvements.

### DIFF
--- a/compile_llvm.sh
+++ b/compile_llvm.sh
@@ -1,78 +1,73 @@
 #!/usr/bin/env bash
 
-LLVM_SRC_DIR=$PWD/llvm-3.5.0
+set -e
 
-if [ -f $LLVM_SRC_DIR/build/Release+Asserts/lib/afl.dylib  ]
-then
-	cp $LLVM_SRC_DIR/build/Release+Asserts/lib/afl.dylib ./afl-llvm-pass.so
-	echo ""
-	echo "Looks like the custom LLVM is already built!"
-	echo "(Delete it manually if you want to rebuild)"
-	exit 0
+LLVM_VERSION="3.5.0"
+LLVM_SRC_DIR="${PWD}/llvm-${LLVM_VERSION}"
+
+if [[ -f "${LLVM_SRC_DIR}/build/Release+Asserts/lib/afl.dylib" ]]; then
+  cp "${LLVM_SRC_DIR}/build/Release+Asserts/lib/afl.dylib" afl-llvm-pass.so
+  echo
+  echo "Looks like the custom LLVM is already built!"
+  echo "(Delete it manually if you want to rebuild)"
+  exit 0
 fi
 
-if [ ! -f llvm-3.5.0.src.tar.xz ]
-then
-	echo ""
-	echo "Downloading LLVM..." 1>&2
-	wget "http://llvm.org/releases/3.5.0/llvm-3.5.0.src.tar.xz"
+if [[ ! -f "llvm-${LLVM_VERSION}.src.tar.xz" ]]; then
+  echo
+  echo "Downloading LLVM"
+  curl -O "http://llvm.org/releases/${LLVM_VERSION}/llvm-${LLVM_VERSION}.src.tar.xz"
 else
-	echo ""
-	echo "Found existing LLVM..."
+  echo
+  echo "Found existing LLVM"
 fi
 
-if [ ! -f cfe-3.5.0.src.tar.xz ]
-then
-	echo ""
-	echo "Downloading Clang..." 1>&2
-	wget "http://llvm.org/releases/3.5.0/cfe-3.5.0.src.tar.xz"
+if [[ ! -f "cfe-${LLVM_VERSION}.src.tar.xz" ]]; then
+  echo
+  echo "Downloading Clang"
+  curl -O "http://llvm.org/releases/${LLVM_VERSION}/cfe-${LLVM_VERSION}.src.tar.xz"
 else
-	echo ""
-	echo "Found existing Clang..."
+  echo
+  echo "Found existing Clang"
 fi 
 
-if [ ! -f compiler-rt-3.5.0.src.tar.xz ]
-then
-	echo ""
-	echo "Downloading Compiler-RT..." 1>&2
-	wget "http://llvm.org/releases/3.5.0/compiler-rt-3.5.0.src.tar.xz"
+if [[ ! -f "compiler-rt-${LLVM_VERSION}.src.tar.xz" ]]; then
+  echo
+  echo "Downloading Compiler-RT"
+  curl -O "http://llvm.org/releases/${LLVM_VERSION}/compiler-rt-${LLVM_VERSION}.src.tar.xz"
 else
-	echo ""
-	echo "Found existing Compiler-RT..."
+  echo
+  echo "Found existing Compiler-RT"
 fi
 
-echo ""
-echo "Unpacking LLVM..." 1>&2
-tar -xf llvm-3.5.0.src.tar.xz
-mv llvm-3.5.0.src $LLVM_SRC_DIR
+echo
+echo "Unpacking LLVM"
+tar xf "llvm-${LLVM_VERSION}.src.tar.xz"
+mv "llvm-${LLVM_VERSION}.src" "${LLVM_SRC_DIR}"
 
-echo ""
-echo "Unpacking Clang into tools..." 1>&2
-tar -xf cfe-3.5.0.src.tar.xz
-mv cfe-3.5.0.src $LLVM_SRC_DIR/tools/clang
+echo
+echo "Unpacking Clang into tools"
+tar xf "cfe-${LLVM_VERSION}.src.tar.xz"
+mv "cfe-${LLVM_VERSION}.src" "${LLVM_SRC_DIR}/tools/clang"
 
-echo ""
-echo "Unpacking Compiler-RT into projects..." 1>&2
-tar -xf compiler-rt-3.5.0.src.tar.xz
-mv compiler-rt-3.5.0.src $LLVM_SRC_DIR/projects/compiler-rt
+echo
+echo "Unpacking Compiler-RT into projects"
+tar xf "compiler-rt-${LLVM_VERSION}.src.tar.xz"
+mv "compiler-rt-${LLVM_VERSION}.src" "${LLVM_SRC_DIR}/projects/compiler-rt"
 
-echo ""
-echo "Copying afl-instr sources" 1>&2
-echo "into LLVM source tree..." 1>&2
-cp -r afl-instr $LLVM_SRC_DIR/projects/
+echo
+echo "Copying afl-instr sources into LLVM source tree"
+cp -r afl-instr "${LLVM_SRC_DIR}/projects/"
 
-echo ""
-echo "Installing LLVM..." 1>&2
-mkdir $LLVM_SRC_DIR/build
-cd $LLVM_SRC_DIR/build
-LLVM_BUILD_DIR=$PWD
+echo
+echo "Installing LLVM"
+mkdir "${LLVM_SRC_DIR}/build"
+cd "${LLVM_SRC_DIR}/build"
 export CC=gcc
 export CXX=g++
 ../configure --enable-optimized 
 REQUIRES_RTTI=1 make -j5
 cd ../..
-cp $LLVM_SRC_DIR/build/Release+Asserts/lib/afl.dylib ./afl-llvm-pass.so
+cp "${LLVM_SRC_DIR}/build/Release+Asserts/lib/afl.dylib" afl-llvm-pass.so
 
-echo "All done..."
-
-
+echo "All done"


### PR DESCRIPTION
Changes:
- Exit immediately if a command exits with a non-zero status (set -e)
- Code now passes shellcheck test
- Introduce variable LLVM_VERSION
- Writing only errors to standard error
- Switched from tabs to spaces
- Using variable syntax ${FOO} instead of $FOO
- Change from ./foo to foo where ./ was implicit
- Small cosmetic changes
